### PR TITLE
Fixed Bug in FileBased Dictionary

### DIFF
--- a/src/Gemstone.IO/Parsing/StreamSerialization.cs
+++ b/src/Gemstone.IO/Parsing/StreamSerialization.cs
@@ -280,8 +280,10 @@ public static class StreamSerialization<T>
         if (!IsListType(type, skipAutoListHandling))
         {
             Action<Stream, object?>? writeMethod = GetWriteMethodForType(type);
+
             if (writeMethod is null)
                 return null;
+
             return (stream, obj) => writeMethod?.Invoke(stream, obj!);
         }
 

--- a/src/Gemstone.IO/Parsing/StreamSerialization.cs
+++ b/src/Gemstone.IO/Parsing/StreamSerialization.cs
@@ -280,6 +280,8 @@ public static class StreamSerialization<T>
         if (!IsListType(type, skipAutoListHandling))
         {
             Action<Stream, object?>? writeMethod = GetWriteMethodForType(type);
+            if (writeMethod is null)
+                return null;
             return (stream, obj) => writeMethod?.Invoke(stream, obj!);
         }
 

--- a/src/UnitTests/Collections/FileBackedDictionaryTest.cs
+++ b/src/UnitTests/Collections/FileBackedDictionaryTest.cs
@@ -745,4 +745,16 @@ public class FileBackedDictionaryTest
         Assert.IsTrue(dictionary[1][2].Name == "Test2.3");
         Assert.IsTrue(dictionary[1][3].Status == ConnectionState.Broken);
     }
+
+    [TestMethod]
+    public void MissingSerializationTest()
+    {
+        using FileBackedDictionary<int, MissingSerializationTest> dictionary = [];
+        Assert.ThrowsException<InvalidOperationException>(
+            () => dictionary.Add(0, new MissingSerializationTest { ID = Guid.NewGuid(), Name = "Test", Status = ConnectionState.Closed })
+            );
+        
+
+
+    }
 }

--- a/src/UnitTests/Collections/MissingSerializationTest.cs
+++ b/src/UnitTests/Collections/MissingSerializationTest.cs
@@ -1,0 +1,51 @@
+﻿//******************************************************************************************************
+//  MissingSerializationTest.cs - Gbtc
+//
+//  Copyright © 2024, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  02/21/2025 - C. Lackner
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Gemstone.IO.UnitTests.Collections;
+
+/// <summary>
+/// Defines an object without Serialization.
+/// </summary>
+public class MissingSerializationTest
+{
+    public MissingSerializationTest()
+    {
+    }
+
+    public MissingSerializationTest(Guid id, string name, ConnectionState status)
+    {
+        ID = id;
+        Name = name;
+        Status = status;
+    }
+
+    public Guid ID { get; set; }
+
+    public string Name { get; set; } = "";
+
+    public ConnectionState Status { get; set; }
+}


### PR DESCRIPTION
This adds a test to make sure we throw an exception if the model is not serializable on Filebased Dictionary and fixes the bug